### PR TITLE
replace functions names by more idiomatic Do() and Must()

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ package main
 import (
 	"os"
 
-	. "github.com/mattn/go-forlines"
+	"github.com/mattn/go-forlines"
 )
 
 func main() {
-	err := ForLines(os.Stdin, func(line string) error {
+	err := forlines.Do(os.Stdin, func(line string) error {
 		return do_something_with(line)
 	})
 	if err != nil {
@@ -29,11 +29,11 @@ package main
 import (
 	"os"
 
-	. "github.com/mattn/go-forlines"
+	"github.com/mattn/go-forlines"
 )
 
 func main() {
-	MustForLines(os.Stdin, func(line string) error {
+	forlines.Must(os.Stdin, func(line string) error {
 		return do_something_with(line)
 	})
 }
@@ -45,11 +45,11 @@ package main
 import (
 	"os"
 
-	. "github.com/mattn/go-forlines"
+	"github.com/mattn/go-forlines"
 )
 
 func main() {
-	MustForLines(os.Stdin, do_something_with(line))
+	forlines.Must(os.Stdin, do_something_with(line))
 }
 ```
 

--- a/forlines.go
+++ b/forlines.go
@@ -6,14 +6,14 @@ import (
 	"io"
 )
 
-func MustForLines(r io.Reader, f func(string) error) {
-	err := ForLines(r, f)
+func Must(r io.Reader, f func(string) error) {
+	err := Do(r, f)
 	if err != nil {
 		panic(err)
 	}
 }
 
-func ForLines(r io.Reader, f func(string) error) error {
+func Do(r io.Reader, f func(string) error) error {
 	br := bufio.NewReader(r)
 	var buf bytes.Buffer
 	for {

--- a/forlines_test.go
+++ b/forlines_test.go
@@ -22,7 +22,7 @@ func TestLinesWithError(t *testing.T) {
 	}
 	got := []string{}
 
-	err = ForLines(f, func(line string) error {
+	err = Do(f, func(line string) error {
 		got = append(got, line)
 		return nil
 	})


### PR DESCRIPTION
this way we can stop dot-importing and goimports will work better
